### PR TITLE
Correct word highlighting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,8 @@ Quran Teleprompter - A SvelteKit 5 web app that displays Quran text and uses spe
 ```bash
 bun install          # Install dependencies
 bun dev              # Start dev server with HMR (hot reloading)
-bun run build        # Build for production to dist/
-bun start            # Run production server
+bun run build        # Build for production to build/
+bun preview          # Preview production build
 bun test             # Run all tests
 bun test <file>      # Run specific test file (e.g., bun test tests/wordMatcher.test.ts)
 ```
@@ -55,7 +55,7 @@ Both are 2D arrays: `[surahIndex][verseIndex] = verseText`. The `dataProcessor.t
 **QuranDataService** (`src/lib/services/QuranDataService.ts`)
 
 - Fetches and caches Quran data in IndexedDB
-- Provides `getSurah()`, `getVerse()`, `getAllSurahs()`
+- Provides `loadData()` and `clearCache()`
 
 **SpeechRecognitionService** (`src/lib/services/SpeechRecognitionService.ts`)
 
@@ -76,7 +76,7 @@ Both are 2D arrays: `[surahIndex][verseIndex] = verseText`. The `dataProcessor.t
 1. User speaks → SpeechRecognitionService emits transcript
 2. `+page.svelte` passes transcript to `matchSpokenWords()` with current verse
 3. Matched word indices stored in `highlightedWords` state (GlobalVerseKey → Set of wordIndices)
-4. When all words matched, ScrollStore triggers `advanceToNextVerse()`
+4. When all words matched, `$effect` in `+page.svelte` triggers `advanceToNextVerse()`
 
 ## Type Definitions
 
@@ -93,4 +93,5 @@ All types in `src/lib/types/index.ts`:
 
 - `SURAH_NAMES` - Array of all 114 surahs with Arabic/English names and verse counts
 - `LANGUAGE_CODE` - Arabic locale for speech recognition (`ar-SA`)
+- `SIMILARITY_THRESHOLD` - Levenshtein match threshold (0.7)
 - `DB_NAME`, `DB_VERSION`, `STORE_NAME`, `CACHE_KEY` - IndexedDB configuration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ The app uses two parallel Quran text sources:
 - `quran-uthmani-list.json` - Full Uthmani script with diacritics (tashkeel) for **display**
 - `quran-simple-clean-list.json` - Simplified Arabic without diacritics for **speech matching**
 
-Both are 2D arrays: `[surahIndex][verseIndex] = verseText`. The `dataProcessor.ts` merges them into a unified structure where each word has both `uthmani` and `simple` variants.
+Both are 2D arrays: `[surahIndex][verseIndex] = verseText`. The `dataProcessor.ts` builds a many-to-one mapping: each simple word gets an `uthmaniIndex` pointing into `verse.uthmani.split(/\s+/)`. Tajweed marks are skipped (no Word points to them); vocative merges produce two Words sharing the same uthmani index.
 
 ### Key Services (Singletons)
 
@@ -74,15 +74,18 @@ Both are 2D arrays: `[surahIndex][verseIndex] = verseText`. The `dataProcessor.t
 ### Data Flow
 
 1. User speaks → SpeechRecognitionService emits transcript
-2. `+page.svelte` passes transcript to `matchSpokenWords()` with current verse
-3. Matched word indices stored in `highlightedWords` state (GlobalVerseKey → Set of wordIndices)
-4. When all words matched, `$effect` in `+page.svelte` triggers `advanceToNextVerse()`
+2. `+page.svelte` passes transcript to `matchSpokenWords()` with current verse's `words[]`
+3. Matched simple-word indices stored in `highlightedWords` (GlobalVerseKey → Set of simple indices)
+4. `VerseRow` derives uthmani highlight set: converts simple indices → uthmani indices via `word.uthmaniIndex`
+5. When `matched.size >= verse.words.length`, `$effect` triggers `advanceToNextVerse()`
 
 ## Type Definitions
 
 All types in `src/lib/types/index.ts`:
 
-- `Surah`, `Verse`, `Word` - Core data structures
+- `Word` `{simple, normalizedSimple, uthmaniIndex}` - Simple word with pointer to uthmani display token
+- `Verse` `{number, uthmani, words}` - Verse text and word mappings
+- `Surah` - Surah metadata and verses
 - `SpeechRecognitionResult`, `SpeechRecognitionCallbacks` - Speech API types
 - `GlobalHighlightedWords` - Map of GlobalVerseKey to Set of highlighted word indices
 - `RenderableItem`, `LookupMaps` - Virtual scrolling support types
@@ -95,3 +98,5 @@ All types in `src/lib/types/index.ts`:
 - `LANGUAGE_CODE` - Arabic locale for speech recognition (`ar-SA`)
 - `SIMILARITY_THRESHOLD` - Levenshtein match threshold (0.7)
 - `DB_NAME`, `DB_VERSION`, `STORE_NAME`, `CACHE_KEY` - IndexedDB configuration
+- `TAJWEED_MARKS` - Set of 9 standalone tajweed/juz mark codepoints in uthmani text
+- `VERSE_ADVANCE_DELAY`, `ERROR_DISMISS_DELAY` - UI timing constants (ms)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,8 +33,8 @@ Quran Teleprompter - A SvelteKit 5 web app that displays Quran text and uses spe
 ```bash
 bun install          # Install dependencies
 bun dev              # Start dev server with HMR (hot reloading)
-bun run build        # Build for production to dist/
-bun start            # Run production server
+bun run build        # Build for production to build/
+bun preview          # Preview production build
 bun test             # Run all tests
 bun test <file>      # Run specific test file (e.g., bun test tests/wordMatcher.test.ts)
 ```
@@ -55,7 +55,7 @@ Both are 2D arrays: `[surahIndex][verseIndex] = verseText`. The `dataProcessor.t
 **QuranDataService** (`src/lib/services/QuranDataService.ts`)
 
 - Fetches and caches Quran data in IndexedDB
-- Provides `getSurah()`, `getVerse()`, `getAllSurahs()`
+- Provides `loadData()` and `clearCache()`
 
 **SpeechRecognitionService** (`src/lib/services/SpeechRecognitionService.ts`)
 
@@ -76,7 +76,7 @@ Both are 2D arrays: `[surahIndex][verseIndex] = verseText`. The `dataProcessor.t
 1. User speaks → SpeechRecognitionService emits transcript
 2. `+page.svelte` passes transcript to `matchSpokenWords()` with current verse
 3. Matched word indices stored in `highlightedWords` state (GlobalVerseKey → Set of wordIndices)
-4. When all words matched, ScrollStore triggers `advanceToNextVerse()`
+4. When all words matched, `$effect` in `+page.svelte` triggers `advanceToNextVerse()`
 
 ## Type Definitions
 
@@ -93,4 +93,5 @@ All types in `src/lib/types/index.ts`:
 
 - `SURAH_NAMES` - Array of all 114 surahs with Arabic/English names and verse counts
 - `LANGUAGE_CODE` - Arabic locale for speech recognition (`ar-SA`)
+- `SIMILARITY_THRESHOLD` - Levenshtein match threshold (0.7)
 - `DB_NAME`, `DB_VERSION`, `STORE_NAME`, `CACHE_KEY` - IndexedDB configuration

--- a/README.md
+++ b/README.md
@@ -89,17 +89,16 @@ Both `quran-uthmani-list.json` and `quran-simple-clean-list.json` are arrays of 
 ### Internal Data Structure
 
 ```typescript
-interface Verse {
-  number: number;
-  uthmani: string;
-  simple: string;
-  words: Word[];
+interface Word {
+  simple: string;            // simple-script word (for matching)
+  normalizedSimple: string;  // pre-normalized for Levenshtein comparison
+  uthmaniIndex: number;      // index into verse.uthmani.split(/\s+/)
 }
 
-interface Word {
-  uthmani: string;
-  simple: string;
-  normalizedSimple: string;
+interface Verse {
+  number: number;
+  uthmani: string;           // full uthmani text (display source)
+  words: Word[];             // one per simple word, maps to uthmani tokens
 }
 
 interface Surah {
@@ -111,6 +110,11 @@ interface Surah {
 }
 ```
 
+The mapping from simple words to uthmani tokens is many-to-one:
+- **Vocative merges** (e.g. يَـٰٓأَيُّهَا = يا + أيها): two `Word` entries share the same `uthmaniIndex`
+- **Tajweed marks** (e.g. ۖ ۗ ۞): uthmani tokens with no `Word` pointing to them
+- Display iterates `uthmani.split(/\s+/)`, highlighting converts simple indices → uthmani indices
+
 ## Architecture
 
 ### Data Layer
@@ -121,11 +125,11 @@ interface Surah {
 - Caches data in `IndexedDB` for offline use
 - Provides methods to get Surah/Verse data
 
-**Data Processing**
+**Data Processing** (`dataProcessor.ts`)
 
-- Merges Uthmani and simple text into unified structure
-- Splits verses into words for word-by-word highlighting
-- Creates mapping between display and recognition words
+- Builds a many-to-one mapping from simple words → uthmani token indices
+- Handles tajweed marks (9 codepoints, skipped) and vocative/demonstrative merges (split into 2 simple words sharing one uthmani index)
+- Pre-computes `normalizedSimple` on each word to avoid per-speech-event normalization
 
 ### Speech Recognition Layer
 

--- a/README.md
+++ b/README.md
@@ -13,42 +13,58 @@ A minimalist, modern web application that helps users read the Quran by automati
 - **Offline Support**: Quran data is embedded and cached in the browser
 - **Minimalist Design**: Clean, modern interface optimized for reading Arabic text (RTL)
 - **Responsive**: Works on desktop and mobile devices
+- **Virtual Scrolling**: Smooth scrolling through 6000+ items using [virtua](https://github.com/inokawa/virtua)
+- **PWA**: Installable with manifest, standalone mode, portrait orientation
 
 ## Technical Stack
 
-- **Frontend Framework**: React
-- **Styling**: Tailwind CSS (via CDN)
+- **Framework**: SvelteKit 2 + Svelte 5 (runes)
+- **Styling**: Tailwind CSS v4
 - **Speech Recognition**: Web Speech API (built-in browser API)
 - **Language**: TypeScript
 - **Runtime**: Bun
+- **Build**: Vite 6, adapter-static (SPA fallback)
 
 ## Project Structure
 
 ```
-taraweeh-mushaf/
-├── public/
-│   └── data/
-│       ├── quran-uthmani-list.json          # Quran text with tashkeel (for display)
-│       └── quran-simple-clean-list.json     # Quran text without tashkeel (for speech recognition)
-├── src/
+src/
+├── routes/
+│   ├── +page.ts                  # Load function: fetches data, builds lookup maps
+│   ├── +page.svelte              # Main UI: speech matching, navigation, effects
+│   ├── +layout.svelte            # Root layout (imports app.css)
+│   └── +error.svelte             # Error page (404, 500)
+├── lib/
 │   ├── components/
-│   │   └── NavigationModal.tsx             # Modal for surah/verse selection
+│   │   ├── QuranVirtualList.svelte  # Virtual scroll container (virtua)
+│   │   ├── VerseRow.svelte          # Single verse with word highlighting
+│   │   ├── SurahHeader.svelte       # Surah title display
+│   │   ├── Bismillah.svelte         # Bismillah separator
+│   │   └── NavigationModal.svelte   # Surah/verse picker modal
 │   ├── services/
-│   │   ├── QuranDataService.ts             # Load and cache Quran data
-│   │   └── SpeechRecognitionService.ts      # Handle speech recognition
-│   ├── utils/
-│   │   ├── dataProcessor.ts                 # Prepare data structure
-│   │   └── constants.ts                     # Surah names, verses counts, etc.
+│   │   ├── QuranDataService.ts      # Fetch + IndexedDB cache (singleton)
+│   │   └── SpeechRecognitionService.ts  # Web Speech API wrapper (singleton)
+│   ├── stores/
+│   │   ├── app.svelte.ts            # Position, highlights, modal state
+│   │   └── speech.svelte.ts         # Reactive wrapper for speech service
 │   ├── types/
-│   │   └── index.ts                         # TypeScript type definitions
-│   ├── App.tsx                              # Main application component
-│   ├── index.tsx                            # Entry point
-│   └── index.css                            # Global styles
-├── tests/                                    # Test files
-├── package.json
-├── bun.lock
-├── tsconfig.json
-└── README.md
+│   │   └── index.ts                 # All TypeScript interfaces
+│   └── utils/
+│       ├── wordMatcher.ts           # Arabic normalization + Levenshtein matching
+│       ├── dataProcessor.ts         # Merge uthmani/simple into Word[] structs
+│       ├── globalAddressing.ts      # Flat index ↔ GlobalVerseKey maps
+│       └── constants.ts             # Surah names, DB config, thresholds
+├── service-worker.ts             # Cache-first for assets, network-first for dynamic
+├── app.css                       # Tailwind v4 config, Amiri font, custom utilities
+└── app.html                      # HTML shell (RTL, meta tags, manifest link)
+
+static/
+├── data/
+│   ├── quran-uthmani-list.json   # Display text (with tashkeel)
+│   └── quran-simple-clean-list.json  # Speech matching text (no tashkeel)
+├── manifest.json                 # PWA manifest
+├── favicon.png
+└── icons/                        # PWA icons (192, 512, maskable)
 ```
 
 ## Data Structure
@@ -63,10 +79,7 @@ Both `quran-uthmani-list.json` and `quran-simple-clean-list.json` are arrays of 
     "بِسْمِ ٱللَّهِ ٱلرَّحْمَـٰنِ ٱلرَّحِيمِ",
     "ٱلْحَمْدُ لِلَّهِ رَبِّ ٱلْعَـٰلَمِينَ"
   ],
-  [
-    "ٱلْم",
-    "ذَٰلِكَ ٱلْكِتَـٰبُ لَا رَيْبَ ۛ فِيهِ ۛ هُدًى لِّلْمُتَّقِينَ"
-  ]
+  ["ٱلْم", "ذَٰلِكَ ٱلْكِتَـٰبُ لَا رَيْبَ ۛ فِيهِ ۛ هُدًى لِّلْمُتَّقِينَ"]
 ]
 ```
 
@@ -86,7 +99,7 @@ interface Verse {
 interface Word {
   uthmani: string;
   simple: string;
-  highlighted: boolean;
+  normalizedSimple: string;
 }
 
 interface Surah {
@@ -103,11 +116,13 @@ interface Surah {
 ### Data Layer
 
 **QuranDataService**
-- Loads both JSON files from `public/data/`
-- Caches data in `localStorage` for offline use
+
+- Loads both JSON files from `static/data/`
+- Caches data in `IndexedDB` for offline use
 - Provides methods to get Surah/Verse data
 
 **Data Processing**
+
 - Merges Uthmani and simple text into unified structure
 - Splits verses into words for word-by-word highlighting
 - Creates mapping between display and recognition words
@@ -115,6 +130,7 @@ interface Surah {
 ### Speech Recognition Layer
 
 **SpeechRecognitionService**
+
 - Wraps Web Speech API
 - Handles Arabic language (`ar-SA`)
 - Emits events for:
@@ -125,14 +141,17 @@ interface Surah {
 ### UI Layer
 
 **Components**
+
 - `NavigationModal`: Modal with Surah and Verse dropdowns
-- `App`: Main application with Quran display and controls
+- `+page.svelte`: Main application with Quran display and controls
 
 **Controls**
+
 - Burger menu (top-right) - Opens navigation modal
 - Microphone button (bottom-center) - Starts/stops speech recognition
 
 **Styling**
+
 - Tailwind CSS for utility classes
 - RTL (Right-to-Left) text direction
 - Arabic font (Amiri)
@@ -168,12 +187,13 @@ bun dev
 bun run build
 
 # Preview production build
-bun start
+bun preview
 ```
 
 ### Browser Requirements
 
 The Web Speech API requires:
+
 - **Chrome/Edge**: Full support (recommended)
 - **Safari**: Limited support, may require user permission
 - **Firefox**: No support for Web Speech API
@@ -205,7 +225,7 @@ The Web Speech API requires:
 - **Browser Support**: Web Speech API not supported in Firefox
 - **Accuracy**: Speech recognition accuracy varies based on pronunciation and microphone quality
 - **Partial Matches**: The app handles partial matches but may miss some words
-- **Offline**: Works offline after initial data load (cached in localStorage)
+- **Offline**: Works offline after initial data load (cached in IndexedDB)
 
 ## Testing
 
@@ -213,11 +233,8 @@ The Web Speech API requires:
 # Run tests
 bun test
 
-# Run linter
-bun run lint
-
 # Type check
-bun run type-check
+bun run check
 ```
 
 ## Contributing
@@ -241,7 +258,7 @@ This is a personal project, but contributions are welcome:
 
 ## Future Enhancements
 
-- [ ] Word-by-word highlighting while reading
+- [x] Word-by-word highlighting while reading
 - [ ] Add multiple recitations (audio playback)
 - [ ] Translation display
 - [ ] Reading speed adjustment

--- a/src/lib/components/VerseRow.svelte
+++ b/src/lib/components/VerseRow.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { SvelteSet } from 'svelte/reactivity';
 	import type { Verse, GlobalVerseKey } from '$lib/types';
 
 	interface Props {
@@ -11,6 +12,19 @@
 	}
 
 	let { verse, verseKey, surahNumber, isCurrentVerse, highlightedWordIndices, onclick }: Props = $props();
+
+	const uthmaniWords = $derived(verse.uthmani.trim().split(/\s+/));
+
+	// Convert simple-word indices → uthmani-word indices for highlighting
+	const highlightedUthmaniSet = $derived.by(() => {
+		if (!highlightedWordIndices) return undefined;
+		const set = new SvelteSet<number>();
+		for (const simpleIdx of highlightedWordIndices) {
+			const word = verse.words[simpleIdx];
+			if (word) set.add(word.uthmaniIndex);
+		}
+		return set;
+	});
 
 	function handleClick() {
 		onclick?.(surahNumber, verse.number);
@@ -37,14 +51,14 @@
 		>
 			{surahNumber}:{verse.number}
 		</span>
-		{#each verse.words as word, wordIndex (wordIndex)}
-			{@const isHighlighted = highlightedWordIndices?.has(wordIndex)}
+		{#each uthmaniWords as uthmaniWord, uIdx (uIdx)}
+			{@const isHighlighted = highlightedUthmaniSet?.has(uIdx)}
 			<span
 				class="inline-block px-1 mx-0.5 rounded transition-all duration-200 {isHighlighted
 					? 'bg-amber-500 text-white font-bold scale-110'
 					: ''}"
 			>
-				{word.uthmani}
+				{uthmaniWord}
 			</span>
 		{/each}
 	</p>

--- a/src/lib/services/QuranDataService.ts
+++ b/src/lib/services/QuranDataService.ts
@@ -32,9 +32,10 @@ export class QuranDataService {
 
 			request.onupgradeneeded = () => {
 				const db = request.result;
-				if (!db.objectStoreNames.contains(STORE_NAME)) {
-					db.createObjectStore(STORE_NAME);
+				if (db.objectStoreNames.contains(STORE_NAME)) {
+					db.deleteObjectStore(STORE_NAME);
 				}
+				db.createObjectStore(STORE_NAME);
 			};
 		});
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,14 +1,14 @@
 export interface Word {
-	uthmani: string;
 	simple: string;
 	normalizedSimple: string;
+	uthmaniIndex: number; // index into verse.uthmaniWords
 }
 
 export interface Verse {
 	number: number;
 	uthmani: string;
 	simple: string;
-	words: Word[];
+	words: Word[]; // one per simple word; uthmaniIndex points into uthmani.split(/\s+/)
 	simpleWordCount: number;
 }
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,15 +1,13 @@
 export interface Word {
 	simple: string;
 	normalizedSimple: string;
-	uthmaniIndex: number; // index into verse.uthmaniWords
+	uthmaniIndex: number; // index into verse.uthmani.split(/\s+/)
 }
 
 export interface Verse {
 	number: number;
 	uthmani: string;
-	simple: string;
 	words: Word[]; // one per simple word; uthmaniIndex points into uthmani.split(/\s+/)
-	simpleWordCount: number;
 }
 
 export interface Surah {

--- a/src/lib/utils/constants.ts
+++ b/src/lib/utils/constants.ts
@@ -120,7 +120,7 @@ export const LANGUAGE_CODE = 'ar-SA';
 
 // IndexedDB configuration
 export const DB_NAME = 'quran-teleprompter';
-export const DB_VERSION = 2;
+export const DB_VERSION = 3;
 export const STORE_NAME = 'cache';
 export const CACHE_KEY = 'quran-data';
 

--- a/src/lib/utils/constants.ts
+++ b/src/lib/utils/constants.ts
@@ -126,3 +126,20 @@ export const CACHE_KEY = 'quran-data';
 
 // Word matching configuration
 export const SIMILARITY_THRESHOLD = 0.7; // Minimum similarity ratio (0-1) for Levenshtein matching
+
+// Timing configuration (ms)
+export const VERSE_ADVANCE_DELAY = 500;
+export const ERROR_DISMISS_DELAY = 3000;
+
+// Standalone tajweed/juz mark codepoints that appear as whitespace-delimited tokens in uthmani
+export const TAJWEED_MARKS = new Set([
+	'\u06D6', // ۖ small high sad
+	'\u06D7', // ۗ small high ain
+	'\u06D8', // ۘ small high meem initial
+	'\u06D9', // ۙ small high lam alef
+	'\u06DA', // ۚ small meem
+	'\u06DB', // ۛ small high three dots
+	'\u06DC', // ۜ small high seen
+	'\u06DE', // ۞ rub el hizb
+	'\u06E9' // ۩ place of sajdah
+]);

--- a/src/lib/utils/dataProcessor.test.ts
+++ b/src/lib/utils/dataProcessor.test.ts
@@ -25,10 +25,11 @@ describe('processQuranData', () => {
 
 describe('word mapping', () => {
 	it('every verse has words.length === simple word count', () => {
-		for (const surah of data.surahs) {
-			for (const verse of surah.verses) {
-				const expected = verse.simple.trim().split(/\s+/).length;
-				expect(verse.words.length, `${surah.number}:${verse.number}`).toBe(expected);
+		for (let i = 0; i < data.surahs.length; i++) {
+			for (let j = 0; j < data.surahs[i].verses.length; j++) {
+				const verse = data.surahs[i].verses[j];
+				const expected = simple[i][j].trim().split(/\s+/).length;
+				expect(verse.words.length, `${data.surahs[i].number}:${verse.number}`).toBe(expected);
 			}
 		}
 	});
@@ -57,15 +58,6 @@ describe('word mapping', () => {
 		}
 	});
 
-	it('simpleWordCount matches non-empty words', () => {
-		for (const surah of data.surahs) {
-			for (const verse of surah.verses) {
-				const nonEmpty = verse.words.filter((w) => w.simple.length > 0).length;
-				expect(verse.simpleWordCount, `${surah.number}:${verse.number}`).toBe(nonEmpty);
-			}
-		}
-	});
-
 	it('6234 verses have exact alignment, only 20:94 and 72:16 have a deficit', () => {
 		// Recount expected simple words per uthmani token using the same rules as dataProcessor
 		const MARKS = new Set(['\u06D6','\u06D7','\u06D8','\u06D9','\u06DA','\u06DB','\u06DC','\u06DE','\u06E9']);
@@ -78,12 +70,13 @@ describe('word mapping', () => {
 		}
 
 		const deficitVerses: string[] = [];
-		for (const surah of data.surahs) {
-			for (const verse of surah.verses) {
+		for (let i = 0; i < data.surahs.length; i++) {
+			for (let j = 0; j < data.surahs[i].verses.length; j++) {
+				const verse = data.surahs[i].verses[j];
 				const uTokens = verse.uthmani.trim().split(/\s+/);
 				const predicted = uTokens.reduce((sum, t) => sum + expectedSimple(t), 0);
-				const actual = verse.simple.trim().split(/\s+/).length;
-				if (predicted !== actual) deficitVerses.push(`${surah.number}:${verse.number}`);
+				const actual = simple[i][j].trim().split(/\s+/).length;
+				if (predicted !== actual) deficitVerses.push(`${data.surahs[i].number}:${verse.number}`);
 			}
 		}
 		expect(deficitVerses).toEqual(['20:94', '72:16']);

--- a/src/lib/utils/dataProcessor.test.ts
+++ b/src/lib/utils/dataProcessor.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { processQuranData } from './dataProcessor';
+import type { QuranRawData } from '$lib/types';
+
+const uthmani: string[][] = JSON.parse(
+	readFileSync('static/data/quran-uthmani-list.json', 'utf-8')
+);
+const simple: string[][] = JSON.parse(
+	readFileSync('static/data/quran-simple-clean-list.json', 'utf-8')
+);
+const rawData: QuranRawData = { uthmani, simple };
+const data = processQuranData(rawData);
+
+describe('processQuranData', () => {
+	it('produces 114 surahs', () => {
+		expect(data.surahs).toHaveLength(114);
+	});
+
+	it('produces 6236 total verses', () => {
+		const total = data.surahs.reduce((sum, s) => sum + s.verses.length, 0);
+		expect(total).toBe(6236);
+	});
+});
+
+describe('word mapping', () => {
+	it('every verse has words.length === simple word count', () => {
+		for (const surah of data.surahs) {
+			for (const verse of surah.verses) {
+				const expected = verse.simple.trim().split(/\s+/).length;
+				expect(verse.words.length, `${surah.number}:${verse.number}`).toBe(expected);
+			}
+		}
+	});
+
+	it('every uthmaniIndex is within bounds', () => {
+		for (const surah of data.surahs) {
+			for (const verse of surah.verses) {
+				const uthmaniLen = verse.uthmani.trim().split(/\s+/).length;
+				for (const word of verse.words) {
+					expect(word.uthmaniIndex, `${surah.number}:${verse.number}`).toBeGreaterThanOrEqual(0);
+					expect(word.uthmaniIndex, `${surah.number}:${verse.number}`).toBeLessThan(uthmaniLen);
+				}
+			}
+		}
+	});
+
+	it('every word has a non-empty normalizedSimple', () => {
+		for (const surah of data.surahs) {
+			for (const verse of surah.verses) {
+				for (const word of verse.words) {
+					if (word.simple) {
+						expect(word.normalizedSimple, `${surah.number}:${verse.number}`).not.toBe('');
+					}
+				}
+			}
+		}
+	});
+
+	it('simpleWordCount matches non-empty words', () => {
+		for (const surah of data.surahs) {
+			for (const verse of surah.verses) {
+				const nonEmpty = verse.words.filter((w) => w.simple.length > 0).length;
+				expect(verse.simpleWordCount, `${surah.number}:${verse.number}`).toBe(nonEmpty);
+			}
+		}
+	});
+
+	it('6234 verses have exact alignment, only 20:94 and 72:16 have a deficit', () => {
+		// Recount expected simple words per uthmani token using the same rules as dataProcessor
+		const MARKS = new Set(['\u06D6','\u06D7','\u06D8','\u06D9','\u06DA','\u06DB','\u06DC','\u06DE','\u06E9']);
+		function expectedSimple(token: string): number {
+			if ([...token].every((ch) => MARKS.has(ch))) return 0;
+			if (/^يَـٰٓ?ـ?َ?ٔ?.+/.test(token)) return 2;
+			if (/^وَيَـٰٓ?ـ?َ?ٔ?.+/.test(token)) return 2;
+			if (token.startsWith('هَـٰٓأَ') || token.startsWith('هَـٰٓأُ')) return 2;
+			return 1;
+		}
+
+		const deficitVerses: string[] = [];
+		for (const surah of data.surahs) {
+			for (const verse of surah.verses) {
+				const uTokens = verse.uthmani.trim().split(/\s+/);
+				const predicted = uTokens.reduce((sum, t) => sum + expectedSimple(t), 0);
+				const actual = verse.simple.trim().split(/\s+/).length;
+				if (predicted !== actual) deficitVerses.push(`${surah.number}:${verse.number}`);
+			}
+		}
+		expect(deficitVerses).toEqual(['20:94', '72:16']);
+	});
+});

--- a/src/lib/utils/dataProcessor.ts
+++ b/src/lib/utils/dataProcessor.ts
@@ -34,9 +34,7 @@ export function processQuranData(rawData: QuranRawData): QuranData {
 			return {
 				number: verseIndex + 1,
 				uthmani: uthmaniText,
-				simple: simpleText,
-				words,
-				simpleWordCount: words.filter((w) => w.simple.length > 0).length
+				words
 			};
 		});
 

--- a/src/lib/utils/dataProcessor.ts
+++ b/src/lib/utils/dataProcessor.ts
@@ -2,6 +2,35 @@ import type { QuranRawData, QuranData, Surah, Verse, Word } from '$lib/types';
 import { SURAH_NAMES } from './constants';
 import { normalizeArabicWord } from './wordMatcher';
 
+/** Standalone tajweed/juz mark codepoints in uthmani */
+const TAJWEED_MARKS = new Set([
+	'\u06D6', // ۖ
+	'\u06D7', // ۗ
+	'\u06D8', // ۘ
+	'\u06D9', // ۙ
+	'\u06DA', // ۚ
+	'\u06DB', // ۛ
+	'\u06DC', // ۜ
+	'\u06DE', // ۞
+	'\u06E9' // ۩
+]);
+
+function isMark(word: string): boolean {
+	for (const ch of word) {
+		if (!TAJWEED_MARKS.has(ch)) return false;
+	}
+	return true;
+}
+
+/** How many simple words a single uthmani token maps to: 0 (mark), 1, or 2 (merge). */
+function simpleWordsPerToken(token: string): number {
+	if (isMark(token)) return 0;
+	if (/^يَـٰٓ?ـ?َ?ٔ?.+/.test(token)) return 2; // يَـٰ vocative merge
+	if (/^وَيَـٰٓ?ـ?َ?ٔ?.+/.test(token)) return 2; // وَيَـٰ conjunction+vocative
+	if (token.startsWith('هَـٰٓأَ') || token.startsWith('هَـٰٓأُ')) return 2; // هَـٰٓأ demonstrative (not هَـٰٓؤ)
+	return 1;
+}
+
 export function processQuranData(rawData: QuranRawData): QuranData {
 	const surahs: Surah[] = [];
 
@@ -12,7 +41,8 @@ export function processQuranData(rawData: QuranRawData): QuranData {
 
 		const verses: Verse[] = uthmaniVerses.map((uthmaniText, verseIndex) => {
 			const simpleText = simpleVerses[verseIndex];
-			const words = splitIntoWords(uthmaniText, simpleText);
+			const uthmaniWords = uthmaniText.trim().split(/\s+/);
+			const words = buildWordMapping(uthmaniWords, simpleText);
 
 			return {
 				number: verseIndex + 1,
@@ -35,20 +65,36 @@ export function processQuranData(rawData: QuranRawData): QuranData {
 	return { surahs };
 }
 
-function splitIntoWords(uthmaniText: string, simpleText: string): Word[] {
-	const uthmaniWords = uthmaniText.trim().split(/\s+/);
+/** Map each simple word to its uthmani token index. */
+function buildWordMapping(uthmaniWords: string[], simpleText: string): Word[] {
 	const simpleWords = simpleText.trim().split(/\s+/);
-
 	const words: Word[] = [];
-	const maxLength = Math.max(uthmaniWords.length, simpleWords.length);
+	let simpleIdx = 0;
 
-	for (let i = 0; i < maxLength; i++) {
-		const simple = simpleWords[i] || '';
+	for (let uIdx = 0; uIdx < uthmaniWords.length; uIdx++) {
+		const count = simpleWordsPerToken(uthmaniWords[uIdx]);
+
+		for (let j = 0; j < count; j++) {
+			const simple = simpleWords[simpleIdx] ?? '';
+			words.push({
+				simple,
+				normalizedSimple: normalizeArabicWord(simple),
+				uthmaniIndex: uIdx
+			});
+			simpleIdx++;
+		}
+	}
+
+	// 20:94 يَبْنَؤُمَّ and 72:16 وَأَلَّوِ — highlighting shifted, completion correct
+	const lastUIdx = uthmaniWords.length - 1;
+	while (simpleIdx < simpleWords.length) {
+		const simple = simpleWords[simpleIdx];
 		words.push({
-			uthmani: uthmaniWords[i] || '',
 			simple,
-			normalizedSimple: normalizeArabicWord(simple)
+			normalizedSimple: normalizeArabicWord(simple),
+			uthmaniIndex: lastUIdx
 		});
+		simpleIdx++;
 	}
 
 	return words;

--- a/src/lib/utils/dataProcessor.ts
+++ b/src/lib/utils/dataProcessor.ts
@@ -1,19 +1,6 @@
 import type { QuranRawData, QuranData, Surah, Verse, Word } from '$lib/types';
-import { SURAH_NAMES } from './constants';
+import { SURAH_NAMES, TAJWEED_MARKS } from './constants';
 import { normalizeArabicWord } from './wordMatcher';
-
-/** Standalone tajweed/juz mark codepoints in uthmani */
-const TAJWEED_MARKS = new Set([
-	'\u06D6', // ۖ
-	'\u06D7', // ۗ
-	'\u06D8', // ۘ
-	'\u06D9', // ۙ
-	'\u06DA', // ۚ
-	'\u06DB', // ۛ
-	'\u06DC', // ۜ
-	'\u06DE', // ۞
-	'\u06E9' // ۩
-]);
 
 function isMark(word: string): boolean {
 	for (const ch of word) {

--- a/src/lib/utils/wordMatcher.ts
+++ b/src/lib/utils/wordMatcher.ts
@@ -64,7 +64,6 @@ export function normalizeArabicWord(word: string): string {
     .replace(/[ئ]/g, "ي")
     .replace(/[ة]/g, "ه")
     .replace(/[\u064B-\u065F]/g, "")
-    .replace(/[\u06D6-\u06ED]/g, "")
     .toLowerCase()
     .trim();
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,7 @@
 	import QuranVirtualList from '$lib/components/QuranVirtualList.svelte';
 	import NavigationModal from '$lib/components/NavigationModal.svelte';
 	import { fade } from 'svelte/transition';
+	import { VERSE_ADVANCE_DELAY, ERROR_DISMISS_DELAY } from '$lib/utils/constants';
 	import type { GlobalHighlightedWords } from '$lib/types';
 
 	let { data } = $props();
@@ -61,7 +62,7 @@
 			appState.highlightedWords = globalMatches;
 
 			if (isVerseComplete(globalMatches)) {
-				const timeoutId = setTimeout(() => advanceToNextVerse(), 500);
+				const timeoutId = setTimeout(() => advanceToNextVerse(), VERSE_ADVANCE_DELAY);
 				return () => clearTimeout(timeoutId);
 			}
 		}
@@ -77,7 +78,7 @@
 	// Auto-dismiss speech error after 3 seconds
 	$effect(() => {
 		if (!speechStore.errorMessage) return;
-		const timeoutId = setTimeout(() => (speechStore.errorMessage = null), 3000);
+		const timeoutId = setTimeout(() => (speechStore.errorMessage = null), ERROR_DISMISS_DELAY);
 		return () => clearTimeout(timeoutId);
 	});
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -30,7 +30,7 @@
 		if (!matched) return false;
 		const verse = currentSurah?.verses[appState.currentVerseNum - 1];
 		if (!verse) return false;
-		return matched.size >= verse.simpleWordCount;
+		return matched.size >= verse.words.length;
 	}
 
 	function advanceToNextVerse(): void {


### PR DESCRIPTION
Issue:
- simple verse and uthmani verse have different counts
- uthmani can merge 2 simple words along with tajweed marks in the middle --> 1 single uthmani word
- we can't rely on the uthmani count for advancing to next verse
- we can't reliably highlight the correct uthmani word from the simple word matched with the transcript

Fix:
- change `Verse`'s `Word`s to keep track of the index of the uthmani word to highlight when that simple word is matched
- 2 verses are the exception where we can't find a mapping w/o hardcoding them --> accept delayed highlighting on these verses in the UI, but moving to next verse is correct